### PR TITLE
build release apk when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ branches:
 script:
   - "./gradlew test"
 before_deploy:
-  - "./gradlew assembleDebug"
+  - "./gradlew assembleRelease"
 deploy:
   provider: releases
   edge: true
   api_key:
     secure: JGUL8WHvwYVtrsYEXXyAGXCKGeRpf0sScTIbuT2kyhS/nWM2hIyY5t06V89qS2V6a1LuVz7Iq4kZgioSaEMfLpUyytM/ozuMYUS9ETG8lHvPXItajn8ytsN8gh2Pw8uMh8s54EFh0v4FCAahLtAoyyILfxNO7aeKRwmcZIK/j87g66DeXgH0ZXJXFwmJMNg9FV0jwlK5HHDmTeo4lk1IzuqUN4B11KbQCdZKW7y6gJGhJypU4Y2gL+bOA79c7BL+C71TPtw8D81lrqVWbegziV3SNSfA5lkY2obiV4lVwovL88ZO4Rrq7y7MgneNUSFqI5rfKUEEyMZvLHbqdRRX9IeHJiWGdyV7kJ72ZmkLlPDnbcA5r+GK14aOoEXkmD827MxMHHDhmVQYyV4A8HBU112ERdYlFx0xqpWi5yhYHa4dQqcTWU526/jy/KjH7uqI+M3miNk3w4mIvUEX7Ret1p2Gv/HL0nQFkwv4kMkxkJCwxtUtR1n+tp7X1gBO32BNu18cCqSh3/qDU5+kRzDeTJAF3Qf1ij6nrwH66/4NoYcmcZ1dOwJ7vCX4cd1tuvoFZM6o/00YOt8VCyz9CszvxE+PHrr/A6zDdaO3FusA1HrHFfnnLUIlxjE1zprlODruf9GDv/PlpqnGj2IcZZeag7tDDldVUPhDVEWAeMqFZD8=
-  file: "RondoApp/build/outputs/apk/debug/RondoApp-debug.apk"
+  file: "RondoApp/build/outputs/apk/release/RondoApp-release.apk"
   name: "Android SDK $LEANPLUM_SDK_VERSION"
   tag: "$LEANPLUM_SDK_VERSION"
   on:

--- a/RondoApp/build.gradle
+++ b/RondoApp/build.gradle
@@ -25,6 +25,11 @@ android {
         buildTypes.each {
             it.buildConfigField "String", "LEANPLUM_SDK_VERSION", "\"${LEANPLUM_SDK_VERSION}\""
         }
+        release {
+            signingConfig signingConfigs.debug // sign with debug key (only for QA purposes)
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
     lintOptions {
         checkReleaseBuilds false

--- a/RondoApp/proguard-rules.pro
+++ b/RondoApp/proguard-rules.pro
@@ -1,21 +1,8 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Proguard rules from Leanplum Developer Guide
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keepclassmembers class *
+{
+  @com.leanplum.annotations.* <fields>;
+}
+-keep class com.leanplum.** { *; }
+-dontwarn com.leanplum.**


### PR DESCRIPTION
Make Rondo-Android build more similar to client SDK integration.

- deploy release build type
- enable proguard for release
- use debug signing key for release